### PR TITLE
Adds visionOS support.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ Contributors
 
 Contributors to the codebase, in reverse chronological order:
 
+- Joseph Quigley, @josephquigley
 - Martin Pittenauer, @m4p
 - Lars, @longinius
 - Christian Gossain, @cgossain

--- a/Sources/Base/OAuth2AuthConfig.swift
+++ b/Sources/Base/OAuth2AuthConfig.swift
@@ -36,15 +36,23 @@ public struct OAuth2AuthConfig {
 		
 		/// By assigning your own UIBarButtonItem (!) you can override the back button that is shown in the iOS embedded web view (does NOT apply to `SFSafariViewController`).
 		public var backButton: AnyObject? = nil
+        
+        /// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
+        public var showCancelButton = true
 		
-		/// If true it makes the login cancellable, otherwise the cancel button is not shown in the embedded web view.
-		public var showCancelButton = true
-		
+        #if os(visionOS) // Must come first per Apple documentation
 		/// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
-		public var useSafariView = true
+		public var useSafariView = false
 		
 		/// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
-		public var useAuthenticationSession = false
+		public var useAuthenticationSession = true
+        #else
+        /// Starting with iOS 9, `SFSafariViewController` will be used for embedded authorization instead of our custom class. You can turn this off here.
+        public var useSafariView = true
+        
+        /// Starting with iOS 12, `ASWebAuthenticationSession` can be used for embedded authorization instead of our custom class. You can turn this on here.
+        public var useAuthenticationSession = false
+        #endif
 		
 		/// May be passed through to [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio).
 		public var prefersEphemeralWebBrowserSession = false

--- a/Sources/Base/OAuth2AuthorizerUI.swift
+++ b/Sources/Base/OAuth2AuthorizerUI.swift
@@ -29,6 +29,8 @@ public protocol OAuth2AuthorizerUI {
 	/// The OAuth2 instance this authorizer belongs to.
 	var oauth2: OAuth2Base { get }
 	
+    #if os(visionOS) // Intentionally blank per Apple documentation
+    #elseif os(iOS)
 	/**
 	Open the authorize URL in the OS browser.
 	
@@ -36,6 +38,7 @@ public protocol OAuth2AuthorizerUI {
 	- throws:        UnableToOpenAuthorizeURL on failure
 	*/
 	func openAuthorizeURLInBrowser(_ url: URL) throws
+    #endif
 	
 	/**
 	Tries to use the given context to present the authorization screen. Context could be a UIViewController for iOS or an NSWindow on macOS.

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -220,14 +220,21 @@ open class OAuth2: OAuth2Base {
 	- parameter params: Optional key/value pairs to pass during authorization
 	*/
 	open func doAuthorize(params: OAuth2StringDict? = nil) throws {
+        #if os(visionOS) // Must come first per Apple documentation
+//        authorizer.authenticationSessionEmbedded
+        try doAuthorizeEmbedded(with: authConfig, params: params)
+        #elseif os(iOS)
 		if authConfig.authorizeEmbedded {
 			try doAuthorizeEmbedded(with: authConfig, params: params)
 		}
 		else {
 			try doOpenAuthorizeURLInBrowser(params: params)
 		}
+        #endif
 	}
 	
+    #if os(visionOS) // Intentionally blank per Apple documentation
+    #elseif os(iOS)
 	/**
 	Open the authorize URL in the OS's browser. Forwards to the receiver's `authorizer`, which is a platform-dependent implementation of
 	`OAuth2AuthorizerUI`.
@@ -240,6 +247,7 @@ open class OAuth2: OAuth2Base {
 		logger?.debug("OAuth2", msg: "Opening authorize URL in system browser: \(url)")
 		try authorizer.openAuthorizeURLInBrowser(url)
 	}
+    #endif
 	
 	/**
 	Tries to use the current auth config context, which on iOS should be a UIViewController and on OS X a NSViewController, to present the

--- a/Sources/iOS/OAuth2WebViewController+iOS.swift
+++ b/Sources/iOS/OAuth2WebViewController+iOS.swift
@@ -17,7 +17,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
+#if os(visionOS) // Intentionally blank per Apple documentation
+#elseif os(iOS)
 
 import UIKit
 import WebKit
@@ -102,7 +103,10 @@ open class OAuth2WebViewController: UIViewController, WKNavigationDelegate {
 	override open func loadView() {
 		edgesForExtendedLayout = .all
 		extendedLayoutIncludesOpaqueBars = true
+        #if os(visionOS) // Intentionally blank per Apple documentation
+        #elseif os(iOS)
 		automaticallyAdjustsScrollViewInsets = true
+        #endif
 		
 		super.loadView()
 		view.backgroundColor = UIColor.white


### PR DESCRIPTION
Many legacy authentication methods that OAuth2 supports are unavailable on visionOS. The only supported method is `ASWebAuthenticationSession`.

This PR compiles out the incompatible code, such as the `OAuth2WebViewController` and `SFSafariViewControllerDelegate`, allowing the visionOS app to compile and run. It also forces the `ASWebAuthenticationSession` method even if the configuration suggests otherwise.