### PR TITLE
Fix for visionOS platform checks that were broken in Xcode 15 Beta 7

### DIFF
--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -23,7 +23,7 @@ import Foundation
  import Base
  #if os(macOS)
   import macOS
- #elseif os(iOS)
+ #elseif os(iOS) || os(visionOS)
   import iOS
  #elseif os(tvOS)
   import tvOS

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -23,7 +23,7 @@ import Foundation
  import Base
  #if os(macOS)
   import macOS
- #elseif os(iOS)
+ #elseif os(iOS) || os(visionOS)
   import iOS
  #elseif os(tvOS)
   import tvOS
@@ -68,7 +68,6 @@ open class OAuth2PasswordGrant: OAuth2 {
 	
 	/// Properties used to handle the native controller.
 	open lazy var customAuthorizer: OAuth2CustomAuthorizerUI = OAuth2CustomAuthorizer()
-	
 	/**
 	If credentials are unknown when trying to authorize, the delegate will be asked a login controller to present.
 	

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -17,7 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
+#if os(visionOS) || os(iOS)
 
 import UIKit
 import SafariServices

--- a/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
+++ b/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
@@ -17,8 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-#if os(iOS)
-
+#if os(visionOS) || os(iOS)
 import Foundation
 import UIKit
 #if !NO_MODULE_IMPORT
@@ -30,9 +29,7 @@ import Base
 An iOS and tvOS-specific implementation of the `OAuth2CustomAuthorizerUI` protocol which modally presents the login controller.
 */
 public class OAuth2CustomAuthorizer: OAuth2CustomAuthorizerUI {
-	
 	private var presentingController: UIViewController?
-	
 	public init() {  }
 	
 	


### PR DESCRIPTION
visionOS `#ifdef` check must come first.